### PR TITLE
hold random ports opened for longer

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension Test-APIcast
 
 {{$NEXT}}
+    - hold random ports opened for longer to reduce collisions
 
 0.11 2018-02-28T14:33:46Z
     - set `metrics` port to the same as APIcast

--- a/lib/Test/APIcast.pm
+++ b/lib/Test/APIcast.pm
@@ -36,6 +36,7 @@ if ($ENV{DEBUG}) {
 
 our @EXPORT = qw( get_random_port );
 
+our @PORTS = ();
 
 sub get_random_port {
     my $tries = 1000;
@@ -52,7 +53,7 @@ sub get_random_port {
         );
 
         if (defined $sock) {
-            $sock->close();
+            push @PORTS, $sock;
             $ServerPort = $port;
             last;
         }
@@ -81,6 +82,14 @@ add_block_preprocessor(sub {
 
     $ENV{TEST_NGINX_RANDOM_PORT} = $block->random_port;
 });
+
+
+sub close_random_ports {
+   my $sock;
+    while (defined($sock = shift @PORTS)){
+        $sock->close();
+    }
+};
 
 our $dns = sub ($$$) {
     my ($host, $ip, $ttl) = @_;
@@ -172,6 +181,18 @@ sub Test::Base::Filter::fixture {
     my $contents = read_file($file);
 
     return $contents;
+}
+
+
+BEGIN {
+    no warnings 'redefine';
+
+    *write_config_file= \&Test::Nginx::Util::write_config_file;
+
+    *Test::Nginx::Util::write_config_file = sub ($$) {
+        write_config_file(@_);
+        close_random_ports();
+    };
 }
 
 1;

--- a/lib/Test/APIcast/Blackbox.pm
+++ b/lib/Test/APIcast/Blackbox.pm
@@ -200,7 +200,9 @@ BEGIN {
 
     sub Test::Nginx::Util::write_config_file ($$) {
         my $block = shift;
-        return $write_nginx_config->($block);
+        $write_nginx_config->($block);
+
+        Test::APIcast::close_random_ports();
     }
 }
 


### PR DESCRIPTION
keep all of the opened sockets for random ports in global array and close them right after generating the nginx config
this should reduce random port clashes because we won't generate random duplicates within one process (multi process is still an issue, but this still could improve the situation)