### PR TITLE
handle decoding JSON errors

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension Test-APIcast
 
 {{$NEXT}}
+    - fixed not failing tests with invalid JSON
 
 0.11 2018-02-28T14:33:46Z
     - set `metrics` port to the same as APIcast

--- a/lib/Test/APIcast/Blackbox.pm
+++ b/lib/Test/APIcast/Blackbox.pm
@@ -69,7 +69,12 @@ _EOC_
 
     if (defined $configuration) {
         $configuration = Test::Nginx::Util::expand_env_in_config($configuration);
-        decode_json($configuration);
+        {
+            local $SIG{__DIE__} = sub {
+                Test::More::fail("$name - configuration block JSON") || Test::More::diag $_[0];
+            };
+            decode_json($configuration);
+        }
         $block->set_value("configuration", $configuration);
     }
 


### PR DESCRIPTION
In some cases when the test was executed it would not fail.