### PR TITLE
introduce test block

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension Test-APIcast
 
 {{$NEXT}}
+    - test block to make test request from nginx/lua
 
 0.12 2018-05-30T17:51:32Z
     - hold random ports opened for longer to reduce collisions


### PR DESCRIPTION
A test block can nginx config for a location to be executed by the test request.
The test does not have to define request as it will be automatically
set to point to the test block.

See an example: https://github.com/3scale/apicast/blob/9288d0d1e9b059cb10ef81a99c475d8b817d449c/t/listen-https.t#L18-L39

Test::Nginx can't make HTTPS requests, so we need some workaround to
call APIcast with HTTPS. lua-nginx-module does the same: https://github.com/openresty/lua-nginx-module/blob/36f341e72858a6dfb861ceb3fbe548b690006acf/t/139-ssl-cert-by.t