### PR TITLE
generate APIcast configuration with env from the env block

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension Test-APIcast
 
 {{$NEXT}}
+    - Pass ENV from env block to apicast config generator
 
 0.12 2018-05-30T17:51:32Z
     - hold random ports opened for longer to reduce collisions

--- a/lib/Test/APIcast/Blackbox.pm
+++ b/lib/Test/APIcast/Blackbox.pm
@@ -130,21 +130,20 @@ my $write_nginx_config = sub {
         }
     }
 
-    my ($env, $env_file) = tempfile();
-
-    my $apicast_cmd = "APICAST_CONFIGURATION_LOADER='test' $apicast_cli start --test --environment $env_file";
-
-    if (defined $configuration_file) {
-        $apicast_cmd .= " --configuration $configuration_file"
-    } else {
-        $configuration_file = "";
-    }
-
     my %env = (%EnvToNginx, $block->env);
     my @env_list = ();
 
     for my $key (keys %env) {
         push @env_list, "$key='$env{$key}'";
+    }
+
+    my ($env, $env_file) = tempfile();
+    my $apicast_cmd = "${\(join(', ', @env_list))} APICAST_CONFIGURATION_LOADER='test' $apicast_cli start --test --environment $env_file";
+
+    if (defined $configuration_file) {
+        $apicast_cmd .= " --configuration $configuration_file"
+    } else {
+        $configuration_file = "";
     }
 
     if (defined $environment) {


### PR DESCRIPTION
Pass the environment variables defined in the env block to the APIcast
command that generates configuration.
This does not change global ENV and behaves more like real environment.