### PR TITLE
fix Test::Nginx ignoring missing directives

### DIFF
--- a/lib/Test/APIcast/Blackbox.pm
+++ b/lib/Test/APIcast/Blackbox.pm
@@ -203,13 +203,15 @@ _EOC_
         warn $apicast_cmd;
     }
 
-    my $apicast = `${apicast_cmd} 2>&1`;
-    if ($apicast =~ /configuration file (?<file>.+?) test is successful/)
+    Test::Nginx::Util::setup_server_root();
+    my $log = `${apicast_cmd} 2>$Test::Nginx::Util::ErrLogFile; cat $Test::Nginx::Util::ErrLogFile`;
+
+    if ($log =~ /configuration file (?<file>.+?) test/)
     {
         move($+{file}, $ConfFile);
     } else {
-        warn "Missing config file: $Test::Nginx::Util::ConfFile";
-        warn $apicast;
+        bail_out("Missing config file: $Test::Nginx::Util::ConfFile");
+        warn $log;
     }
 
     if ($PidFile && -f $PidFile) {
@@ -219,8 +221,46 @@ _EOC_
     $ENV{APICAST_LOADED_ENVIRONMENTS} = join('|',$ env_file, $block->environment_file);
 };
 
+sub ignore_missing_directives($) {
+    my $block = shift;
+    my $ServRoot = $Test::Nginx::Util::ServRoot;
+    my $ConfFile = $Test::Nginx::Util::ConfFile;
+    my $NginxBinary = $Test::Nginx::Util::NginxBinary;
+    my $ErrLogFile = $Test::Nginx::Util::ErrLogFile;
+
+    if (defined $ENV{TEST_NGINX_IGNORE_MISSING_DIRECTIVES}) {
+        Test::Nginx::Util::setup_server_root();
+
+        $write_nginx_config->($block);
+
+        my $test = system("$NginxBinary -p $ServRoot -c $ConfFile -t 2> $ErrLogFile");
+
+        if ( $test != 0) {
+
+            if (my $directive = Test::Nginx::Util::check_if_missing_directives())
+            {
+                return $directive;
+            }
+        }
+    }
+}
+
 BEGIN {
     no warnings 'redefine';
+
+    *original_run_test = \&Test::Nginx::Util::run_test;
+    *Test::Nginx::Util::run_test = sub ($) {
+        my $block = shift;
+
+        SKIP: {
+            my $missing_directive = ignore_missing_directives($block);
+            my $name = $block->name;
+            skip "$name -- tests skipped because of the lack of directive $missing_directive" if $missing_directive;
+
+            original_run_test($block);
+        }
+
+    };
 
     sub Test::Nginx::Util::write_config_file ($$) {
         my $block = shift;
@@ -228,6 +268,29 @@ BEGIN {
 
         Test::APIcast::close_random_ports();
     }
+
+
+    # Copy-paste from Test::Nginx::Util
+
+    sub Test::Nginx::Util::check_if_missing_directives () {
+        my $logfile = $Test::Nginx::Util::ErrLogFile;
+
+        open my $in, $logfile or
+            bail_out "check_if_missing_directives: Cannot open $logfile for reading: $!\n";
+
+        while (<$in>) {
+            warn "LINE: $_";
+            # This is changed as the format is following: [emerg] unknown directive "name"
+            if (/\[emerg\] unknown directive "([^"]+)"/) {
+                return $1;
+            }
+        }
+
+        close $in;
+
+        return 0;
+    }
+
 }
 
 our @EXPORT = qw(


### PR DESCRIPTION
There is several issues with TEST_NGINX_IGNORE_MISSING_DIRECTIVES:

1) the regex to get the missing directive is wrong
2) it does not get the error log correctly
3) it still runs udp reply tests

So in this version we try to skip the whole run_tests method if the
config is not valid because of missing directive.