### PR TITLE
add support to modify the nginx configuration file in blackbox tests

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension Test-APIcast
 
 {{$NEXT}}
+   - Add `Test::Nginx::Socket::set_http_config_filter` support to Test::APIcast::Blackbox
    - Change ENV instead of passing it to APIcast executable
 
 0.14 2018-06-06T13:02:23Z

--- a/lib/Test/APIcast/Blackbox.pm
+++ b/lib/Test/APIcast/Blackbox.pm
@@ -7,6 +7,7 @@ use JSON;
 use Test::APIcast -Base;
 use File::Copy "move";
 use File::Temp qw/ tempfile /;
+use File::Slurp qw(read_file);
 
 BEGIN {
     $ENV{APICAST_OPENRESTY_BINARY} = $ENV{TEST_NGINX_BINARY};
@@ -106,6 +107,7 @@ _EOC_
 my $write_nginx_config = sub {
     my $block = shift;
 
+    my $FilterHttpConfig = $Test::Nginx::Util::FilterHttpConfig;
     my $ConfFile = $Test::Nginx::Util::ConfFile;
     my $Workers = $Test::Nginx::Util::Workers;
     my $MasterProcessEnabled = $Test::Nginx::Util::MasterProcessEnabled;
@@ -215,7 +217,16 @@ _EOC_
     my $apicast = `${apicast_cmd} 2>&1`;
     if ($apicast =~ /configuration file (?<file>.+?) test is successful/)
     {
-        move($+{file}, $ConfFile);
+        open(my $fh, '+>', $ConfFile) or die "cannot open $ConfFile: $!";
+
+        my $nginx_config = read_file($+{file});
+
+        if ($FilterHttpConfig) {
+            $nginx_config = $FilterHttpConfig->($nginx_config);
+        }
+
+        print { $fh } $nginx_config;
+        close($fh);
     } else {
         warn "Missing config file: $Test::Nginx::Util::ConfFile";
         warn $apicast;


### PR DESCRIPTION
It can also be used to do something after server prefix was cleaned up.

This is supported in normal Test::Nginx tests: https://github.com/openresty/test-nginx/blob/a598ad167659b37637772ce17819442379ee66e6/lib/Test/Nginx/Util.pm#L885-L887