### PR TITLE
Revert "Revert "fix Test::Nginx ignoring missing directives""

### DIFF
--- a/lib/Test/APIcast/Blackbox.pm
+++ b/lib/Test/APIcast/Blackbox.pm
@@ -252,8 +252,10 @@ _EOC_
         warn $apicast_cmd;
     }
 
-    my $apicast = `${apicast_cmd} 2>&1`;
-    if ($apicast =~ /configuration file (?<file>.+?) test is successful/)
+    Test::Nginx::Util::setup_server_root();
+    my $log = `${apicast_cmd} 2>$Test::Nginx::Util::ErrLogFile; cat $Test::Nginx::Util::ErrLogFile`;
+
+    if ($log =~ /configuration file (?<file>.+?) test/)
     {
         open(my $fh, '+>', $ConfFile) or die "cannot open $ConfFile: $!";
 
@@ -266,8 +268,8 @@ _EOC_
         print { $fh } $nginx_config;
         close($fh);
     } else {
-        warn "Missing config file: $Test::Nginx::Util::ConfFile";
-        warn $apicast;
+        bail_out("Missing config file: $Test::Nginx::Util::ConfFile");
+        warn $log;
     }
 
     if ($PidFile && -f $PidFile) {
@@ -276,6 +278,30 @@ _EOC_
 
     $ENV{APICAST_LOADED_ENVIRONMENTS} = join('|',@environments);
 };
+
+sub ignore_missing_directives($) {
+    my $block = shift;
+    my $ServRoot = $Test::Nginx::Util::ServRoot;
+    my $ConfFile = $Test::Nginx::Util::ConfFile;
+    my $NginxBinary = $Test::Nginx::Util::NginxBinary;
+    my $ErrLogFile = $Test::Nginx::Util::ErrLogFile;
+
+    if (defined $ENV{TEST_NGINX_IGNORE_MISSING_DIRECTIVES}) {
+        Test::Nginx::Util::setup_server_root();
+
+        $write_nginx_config->($block);
+
+        my $test = system("$NginxBinary -p $ServRoot -c $ConfFile -t 2> $ErrLogFile");
+
+        if ( $test != 0) {
+
+            if (my $directive = Test::Nginx::Util::check_if_missing_directives())
+            {
+                return $directive;
+            }
+        }
+    }
+}
 
 add_block_preprocessor(sub {
     if (defined $original_server_port_for_client) {
@@ -287,12 +313,49 @@ add_block_preprocessor(sub {
 BEGIN {
     no warnings 'redefine';
 
+    *original_run_test = \&Test::Nginx::Util::run_test;
+    *Test::Nginx::Util::run_test = sub ($) {
+        my $block = shift;
+
+        SKIP: {
+            my $missing_directive = ignore_missing_directives($block);
+            my $name = $block->name;
+            skip "$name -- tests skipped because of the lack of directive $missing_directive" if $missing_directive;
+
+            original_run_test($block);
+        }
+
+    };
+
     sub Test::Nginx::Util::write_config_file ($$) {
         my $block = shift;
         $write_nginx_config->($block);
 
         Test::APIcast::close_random_ports();
     }
+
+
+    # Copy-paste from Test::Nginx::Util
+
+    sub Test::Nginx::Util::check_if_missing_directives () {
+        my $logfile = $Test::Nginx::Util::ErrLogFile;
+
+        open my $in, $logfile or
+            bail_out "check_if_missing_directives: Cannot open $logfile for reading: $!\n";
+
+        while (<$in>) {
+            # warn "LINE: $_";
+            # This is changed as the format is following: [emerg] unknown directive "name"
+            if (/\[emerg\] unknown directive "([^"]+)"/) {
+                return $1;
+            }
+        }
+
+        close $in;
+
+        return 0;
+    }
+
 }
 
 our @EXPORT = qw(


### PR DESCRIPTION
Reverts 3scale/Test-APIcast#16

This PR crashes APIcast test suite:

```

t/http-proxy.t .. /var/folders/4j/8_8n41pn79x__h1005mb3jnm0000gn/T/fsd6qRdC5M at t/http_proxy.pl line 45, <DATA> line 1.
nginx: [emerg] BIO_new_file("/Users/mikz/Developer/3scale/apicast/t/servroot_20800/html/server.crt") failed (SSL: error:02001002:system library:fopen:No such file or directory:fopen('/Users/mikz/Developer/3scale/apicast/t/servroot_20800/html/server.crt','r') error:2006D080:BIO routines:BIO_new_file:no such file)
Bailout called.  Further testing stopped:  TEST 5: 3scale backend connection uses proxy for HTTPS - Cannot start nginx using command "openresty -p /Users/mikz/Developer/3scale/apicast/t/servroot_20800/ -c /Users/mikz/Developer/3scale/apicast/t/servroot_20800/conf/nginx.conf > /dev/null" (status code 256).
```