### PR TITLE
disable timer resolution

### DIFF
--- a/lib/Test/APIcast/Blackbox.pm
+++ b/lib/Test/APIcast/Blackbox.pm
@@ -224,6 +224,7 @@ return {
     master_process = '$MasterProcessEnabled',
     daemon = '$DaemonEnabled',
     error_log = '$err_log_file',
+    timer_resolution = false,
     log_level = '$LogLevel',
     pid = '$PidFile',
     lua_code_cache = 'on',


### PR DESCRIPTION
when used with debug mode it produces several log lines every 100ms
```
2019/05/21 08:34:35 [debug] 64313#8376796: timer delta: 100
2019/05/21 08:34:35 [debug] 64313#8376796: worker cycle
2019/05/21 08:34:35 [debug] 64313#8376796: kevent timer: -1, changes: 0
2019/05/21 08:34:35 [debug] 64313#8376796: kevent events: 1
2019/05/21 08:34:35 [debug] 64313#8376796: kevent: 0: ft:-7 fl:0025 ff:00000000 d:1 ud:0000000000000000
```