### PR TITLE
Get random port fixes

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -2,6 +2,7 @@ requires 'perl', '5.008001';
 requires 'Test::Nginx', '>= 0.26';
 requires 'JSON', '>= 2';
 requires 'File::Slurp';
+requires 'flock';
 
 on 'test' => sub {
     requires 'Test::More', '0.98';

--- a/lib/Test/APIcast.pm
+++ b/lib/Test/APIcast.pm
@@ -2,6 +2,7 @@ package Test::APIcast;
 use v5.10.1;
 use strict;
 use warnings FATAL => 'all';
+use Fcntl qw(:flock SEEK_END);
 
 our $VERSION = "0.22";
 
@@ -38,10 +39,22 @@ our @EXPORT = qw( get_random_port );
 
 our @PORTS = ();
 
+open(my $prove_filename_lock, ">", "/tmp/prove_lock");
+
+sub lock {
+    flock($prove_filename_lock, LOCK_EX) or bail_out "cannot get prove lock.";
+    # and, in case someone appended while we were waiting...
+    seek($prove_filename_lock, 0, SEEK_END) or bail_out "cannot get prove lock.";
+}
+
+sub unlock {
+    flock($prove_filename_lock, LOCK_UN) or bail_out "Cannot release prove lock";
+}
+
 sub get_random_port {
     my $tries = 1000;
     my $ServerPort;
-
+    lock();
     for (my $i = 0; $i < $tries; $i++) {
         my $port = int(rand 60000) + 1025;
 
@@ -62,6 +75,7 @@ sub get_random_port {
             warn "Try again, port $port is already in use: $@\n";
         }
     }
+    unlock();
 
     if (!defined $ServerPort) {
         bail_out "Cannot find an available listening port number after $tries attempts.\n";

--- a/lib/Test/APIcast.pm
+++ b/lib/Test/APIcast.pm
@@ -46,13 +46,13 @@ sub get_random_port {
         my $port = int(rand 60000) + 1025;
 
         my $sock = IO::Socket::INET->new(
-            LocalAddr => $Test::Nginx::Util::ServerAddr,
             LocalPort => $port,
             Proto => 'tcp',
-            Timeout => 0.1,
         );
 
         if (defined $sock) {
+            $sock->shutdown(0);
+            $sock->close();
             push @PORTS, $sock;
             $ServerPort = $port;
             last;


### PR DESCRIPTION
With these changes, APICast integration tests will not fail due address is already bind. 