### PR TITLE
CPANFILE: delete flock from cpanfile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Test::APIcast - Testing framework for [APIcast](https://github.com/3scale/apicast).
 
+[![CircleCI](https://circleci.com/gh/3scale/Test-APIcast/tree/master.svg?style=shield)](https://circleci.com/gh/3scale/Test-APIcast/tree/master)
+
 # SYNOPSIS
 
     use Test::APIcast;

--- a/cpanfile
+++ b/cpanfile
@@ -2,7 +2,6 @@ requires 'perl', '5.008001';
 requires 'Test::Nginx', '>= 0.26';
 requires 'JSON', '>= 2';
 requires 'File::Slurp';
-requires 'flock';
 
 on 'test' => sub {
     requires 'Test::More', '0.98';


### PR DESCRIPTION
Due to a mistake, I added this requirement into cpanfile that it is
already in perl 5.

https://perldoc.perl.org/functions/flock.html

Fix build: https://circleci.com/gh/3scale/Test-APIcast/57

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>